### PR TITLE
give ot holders interests after expiry

### DIFF
--- a/contracts/core/BenchmarkAaveForge.sol
+++ b/contracts/core/BenchmarkAaveForge.sol
@@ -147,11 +147,16 @@ contract BenchmarkAaveForge is IBenchmarkForge, ReentrancyGuard {
         redeemedAmount = tokens.ot.balanceOf(_msgSender);
 
         aToken.transfer(_to, redeemedAmount);
-        uint256 currentNormalizedIncome = aaveLendingPoolCore.getReserveNormalizedIncome(_underlyingAsset);
+        uint256 currentNormalizedIncome =
+            aaveLendingPoolCore.getReserveNormalizedIncome(_underlyingAsset);
 
         // interests from the timestamp of the last XYT transfer (before expiry) to now is entitled to the OT holders
         // this means that the OT holders are getting some extra interests, at the expense of XYT holders
-        uint256 interestsAfterExpiry = currentNormalizedIncome.mul(redeemedAmount).div(lastNormalisedIncomeBeforeExpiry[_underlyingAsset][_expiry]).sub(redeemedAmount);
+        uint256 interestsAfterExpiry =
+            currentNormalizedIncome
+                .mul(redeemedAmount)
+                .div(lastNormalisedIncomeBeforeExpiry[_underlyingAsset][_expiry])
+                .sub(redeemedAmount);
         aToken.transfer(_to, interestsAfterExpiry);
 
         _settleDueInterests(tokens, _underlyingAsset, _expiry, _msgSender);


### PR DESCRIPTION
When redeeming after expiry, OT holders will get the interests from the "Timestamp of the last xyt/ot operation before the expiry" (when `lastNormalisedIncomeBeforeExpiry` is saved)