### PR TITLE
Avoid double aToken transfer to save gas in redeemAfterExpiry

### DIFF
--- a/contracts/core/PendleAaveForge.sol
+++ b/contracts/core/PendleAaveForge.sol
@@ -124,7 +124,7 @@ contract PendleAaveForge is IPendleForge, Permissions, ReentrancyGuard {
         IERC20 aToken = IERC20(getYieldBearingToken(_underlyingAsset));
         PendleTokens memory tokens = _getTokens(_underlyingAsset, _expiry);
         redeemedAmount = tokens.ot.balanceOf(_account);
-        
+
         uint256 currentNormalizedIncome =
             aaveLendingPoolCore.getReserveNormalizedIncome(_underlyingAsset);
 


### PR DESCRIPTION
It turns out that `getReserveNormalizedIncome` is already updated when called from Aave, without the need to do the 1st transfer.

Closes #49 